### PR TITLE
Convert to RGB before saving as JPEG.

### DIFF
--- a/pydenticon/__init__.py
+++ b/pydenticon/__init__.py
@@ -246,6 +246,9 @@ class Generator(object):
         # Set-up a stream where image will be saved.
         stream = BytesIO()
 
+        if image_format.upper() == "JPEG":
+            image = image.convert(mode="RGB")
+
         # Save the image to stream.
         try:
             image.save(stream, format=image_format, optimize=True)


### PR DESCRIPTION
Pillow 3.7 removes support for saving RGBA images as JPEG.

Images need to be converted explicitly before saving, or errors like [this](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=871079) happen.